### PR TITLE
Prevent mmStr from emitting scientific notation for small metric values

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -9,6 +9,12 @@ const unitToMm: { [key: string]: number } = {
   feet: 304.8,
 }
 
+const mmNumberFormatter = new Intl.NumberFormat("en-US", {
+  useGrouping: false,
+  notation: "standard",
+  maximumFractionDigits: 12,
+})
+
 export const mm = (n: number | string): number => {
   let unit =
     typeof n === "number" ? "mm" : n.replace(/^[^a-zA-Z]+/g, "").toLowerCase()
@@ -22,7 +28,7 @@ export const mm = (n: number | string): number => {
 }
 
 export const mmStr = (n: number | string): string => {
-  return `${mm(n)}mm`
+  return `${mmNumberFormatter.format(mm(n))}mm`
 }
 
 export const mil2mm = (mil: number | string) => {

--- a/tests/basic.test.ts
+++ b/tests/basic.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test"
-import mm from "../index.ts"
+import mm, { mmStr } from "../index.ts"
 
 test("1in", () => {
   expect(mm("1in")).toBeCloseTo(25.4)
@@ -15,4 +15,12 @@ test("0.8mm", () => {
 })
 test("100mil", () => {
   expect(mm("100mil")).toBeCloseTo(2.54)
+})
+
+test("mmStr avoids scientific notation", () => {
+  expect(mmStr(1e-7)).toBe("0.0000001mm")
+})
+
+test("mmStr formats converted units without scientific notation", () => {
+  expect(mmStr("0.0000001in")).toBe("0.00000254mm")
 })


### PR DESCRIPTION
Description

  ## Summary

  This PR fixes a subtle formatting bug in mmStr where very small values could be returned in scientific notation (for example 1e-7mm) instead of a plain decimal millimeter string.

  mmStr now formats output with Intl.NumberFormat using standard notation, so callers consistently receive decimal strings like 0.0000001mm.

  ## Why This Change

  Scientific notation is awkward for downstream display, serialization, and user-facing output. Since mmStr is intended to produce a readable millimeter string, returning exponential notation breaks that
  expectation for very small values.

  ## Fix

  - Format mmStr output with Intl.NumberFormat
  - Disable grouping so values remain machine- and human-friendly
  - Force standard notation to avoid exponential output

  ## Reproduction And Tests

  This PR includes tests that reproduce the bug and verify the fix:

  - mmStr(1e-7) now returns 0.0000001mm
  - mmStr("0.0000001in") now returns 0.00000254mm

  ## Impact

  This is a subtle but important bug fix with test coverage, and it keeps mmStr output stable and readable for very small converted values.